### PR TITLE
Remove unused Vercel KV dependency to unblock deployment integration.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@react-email/components": "^1.0.1",
-        "@vercel/kv": "^3.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.546.0",
@@ -1978,27 +1977,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@upstash/redis": {
-      "version": "1.35.6",
-      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.6.tgz",
-      "integrity": "sha512-aSEIGJgJ7XUfTYvhQcQbq835re7e/BXjs8Janq6Pvr6LlmTZnyqwT97RziZLO/8AVUL037RLXqqiQC6kCt+5pA==",
-      "license": "MIT",
-      "dependencies": {
-        "uncrypto": "^0.1.3"
-      }
-    },
-    "node_modules/@vercel/kv": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
-      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@upstash/redis": "^1.34.0"
-      },
-      "engines": {
-        "node": ">=14.6"
       }
     },
     "node_modules/accepts": {
@@ -4351,12 +4329,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/uncrypto": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@react-email/components": "^1.0.1",
-    "@vercel/kv": "^3.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.546.0",


### PR DESCRIPTION
Drop @vercel/kv and its transitive packages since the codebase does not use them, preventing preview deploy failures during integration provisioning.

Made-with: Cursor